### PR TITLE
Fix version requirement of RxSwift

### DIFF
--- a/When.podspec
+++ b/When.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.subspec "RxSwift" do |ss|
     ss.source_files = "Sources/RxWhen/**/*"
     ss.dependency "When/Core"
-    ss.dependency "RxSwift", "~> 3.2.0"
+    ss.dependency "RxSwift", "~> 3.0"
   end
 end


### PR DESCRIPTION
I think allowing any version from 3.0 is enough, we do not need to be strict on 3.2