### PR TITLE
Improvements

### DIFF
--- a/Sources/When/Functions.swift
+++ b/Sources/When/Functions.swift
@@ -17,7 +17,7 @@ public func when<T, U, V>(_ p1: Promise<T>, _ p2: Promise<U>, _ p3: Promise<V>) 
   }
 }
 
-private func when<T>(_ promises: [Promise<T>]) -> Promise<Void> {
+public func when<T>(_ promises: [Promise<T>]) -> Promise<Void> {
   let masterPromise = Promise<Void>()
   var (total, resolved) = (promises.count, 0)
 

--- a/Sources/When/Functions.swift
+++ b/Sources/When/Functions.swift
@@ -6,37 +6,40 @@ let instantQueue = DispatchQueue(label: "When.InstantQueue", attributes: [])
 let barrierQueue = DispatchQueue(label: "When.BarrierQueue", attributes: DispatchQueue.Attributes.concurrent)
 
 public func when<T, U>(_ p1: Promise<T>, _ p2: Promise<U>) -> Promise<(T, U)> {
-  return when([p1.asVoid(), p2.asVoid()]).then(on: instantQueue) {
+  return when([p1.asVoid(), p2.asVoid()]).then(on: instantQueue) { _ in
     (p1.state.result!.value!, p2.state.result!.value!)
   }
 }
 
 public func when<T, U, V>(_ p1: Promise<T>, _ p2: Promise<U>, _ p3: Promise<V>) -> Promise<(T, U, V)> {
-  return when([p1.asVoid(), p2.asVoid(), p3.asVoid()]).then(on: instantQueue) {
+  return when([p1.asVoid(), p2.asVoid(), p3.asVoid()]).then(on: instantQueue) { _ in
     (p1.state.result!.value!, p2.state.result!.value!, p3.state.result!.value!)
   }
 }
 
-public func when<T>(_ promises: [Promise<T>]) -> Promise<Void> {
-  let masterPromise = Promise<Void>()
-  var (total, resolved) = (promises.count, 0)
-
-  promises.forEach { promise in
-    promise
-      .done({ value in
-        barrierQueue.sync(flags: .barrier, execute: {
-          resolved += 1
-          if resolved == total {
-            masterPromise.resolve()
-          }
-        }) 
-      })
-      .fail({ error in
-        barrierQueue.sync(flags: .barrier, execute: {
-          masterPromise.reject(error)
-        }) 
-      })
-  }
-
-  return masterPromise
+public func when<T>(_ promises: [Promise<T>]) -> Promise<[T]> {
+    let masterPromise = Promise<[T]>()
+    var (total, resolved) = (promises.count, 0)
+    
+    if promises.isEmpty {
+        masterPromise.resolve([])
+    } else {
+        promises.forEach { promise in
+            _=promise
+                .done({ value in
+                    barrierQueue.sync {
+                        resolved += 1
+                        if resolved == total {
+                            masterPromise.resolve(promises.map{ $0.state.result!.value! })
+                        }
+                    }
+                })
+                .fail({ error in
+                    barrierQueue.sync {
+                        masterPromise.reject(error)
+                    }
+                })
+        }
+    }
+    return masterPromise
 }

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -9,7 +9,7 @@ open class Promise<T> {
   open let key = UUID().uuidString
 
   var queue: DispatchQueue
-  fileprivate(set) var state: State<T>
+  fileprivate(set) public var state: State<T>
 
   fileprivate(set) var observer: Observer<T>?
   fileprivate(set) var doneHandler: DoneHandler?

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -45,6 +45,10 @@ open class Promise<T> {
     self.queue = queue
     self.state = state
   }
+    
+  public convenience init(queue: DispatchQueue = mainQueue, _ value: T) {
+    self.init(queue: queue, state: .resolved(value: value))
+  }
 
   // MARK: - States
 

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -31,6 +31,15 @@ open class Promise<T> {
         }
     }
   }
+    
+  public init(queue: DispatchQueue = mainQueue, _ body: @escaping (_ resolve: (T) -> Void, _ reject: (Error) -> Void) -> Void) {
+    state = .pending
+    self.queue = queue
+    
+    dispatch(queue) {
+        body(self.resolve, self.reject)
+    }
+  }
 
   public init(queue: DispatchQueue = mainQueue, state: State<T> = .pending) {
     self.queue = queue

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -18,15 +18,17 @@ open class Promise<T> {
 
   // MARK: - Initialization
 
-  public init(queue: DispatchQueue = mainQueue, _ body: (Void) throws -> T) {
+  public init(queue: DispatchQueue = mainQueue, _ body: @escaping (Void) throws -> T) {
     state = .pending
     self.queue = queue
 
-    do {
-      let value = try body()
-      resolve(value)
-    } catch {
-      reject(error)
+    dispatch(queue) {
+        do {
+          let value = try body()
+          self.resolve(value)
+        } catch {
+          self.reject(error)
+        }
     }
   }
 


### PR DESCRIPTION
- Made when([Promise<T>]) -> Promise<Void> function public
- Made the Promise.state property public readable
- Added Promise{ resolve, reject in ... } init syntax, used in other Promise libraries and missing here
- Running Promise init block code on the queue provided in the init(queue:) argument, it seems incorrect to run the Promise block synchronously on the same queue it was created