### PR TITLE
Promise: Add convenience API for converting an async function to a promise

### DIFF
--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -18,6 +18,7 @@ open class Promise<T> {
 
   // MARK: - Initialization
 
+  /// Create a promise that resolves using a synchronous closure
   public init(queue: DispatchQueue = mainQueue, _ body: @escaping (Void) throws -> T) {
     state = .pending
     self.queue = queue
@@ -31,7 +32,8 @@ open class Promise<T> {
       }
     }
   }
-    
+
+  /// Create a promise that resolves using an asynchronous closure that can either resolve or reject
   public init(queue: DispatchQueue = mainQueue,
               _ body: @escaping (_ resolve: (T) -> Void, _ reject: (Error) -> Void) -> Void) {
     state = .pending
@@ -42,6 +44,17 @@ open class Promise<T> {
     }
   }
 
+  /// Create a promise that resolves using an asynchronous closure that can only resolve
+  public init(queue: DispatchQueue = mainQueue, _ body: @escaping (@escaping (T) -> Void) -> Void) {
+    state = .pending
+    self.queue = queue
+
+    dispatch(queue) {
+      body(self.resolve)
+    }
+  }
+
+  /// Create a promise with a given state
   public init(queue: DispatchQueue = mainQueue, state: State<T> = .pending) {
     self.queue = queue
     self.state = state

--- a/WhenTests/Shared/PromiseSpec.swift
+++ b/WhenTests/Shared/PromiseSpec.swift
@@ -98,6 +98,35 @@ class PromiseSpec: QuickSpec {
             self.waitForExpectations(timeout: 2.0, handler:nil)
           }
         }
+
+        context("with an async body that returns a value") {
+          let string = "Success!"
+
+          func loadString(withCompletionHandler handler: @escaping (String) -> Void) {
+            DispatchQueue(label: "async closure").async {
+              handler(string)
+            }
+          }
+
+          beforeEach {
+            promise = Promise(loadString)
+          }
+
+          it("resolves the promise") {
+            let doneExpectation = self.expectation(description: "Done expectation")
+
+            promise.done { value in
+              expect(value).to(equal(string))
+              expect(promise.state.isResolved).to(beTrue())
+              expect(promise.state.result?.value).to(equal(string))
+              expect(promise.state.result?.error).to(beNil())
+
+              doneExpectation.fulfill()
+            }
+
+            self.waitForExpectations(timeout: 2.0, handler: nil)
+          }
+        }
       }
 
       describe("#reject") {


### PR DESCRIPTION
This change introduces a new initializer on `Promise` that takes a `body` that can **only resolve** a value. The use case is to be able to convert functions that take a completion handler into a `Promise` in a simple way, such as when loading user notification status: 

```swift
let center = UNUserNotificationCenter.current()
let promise = Promise(center.getNotificationSettings)

promise.done { status in
    // Handle status
}
```