### PR TITLE
Feature: promise recover

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ asynchronous code up to the next level.
   * [Fail](#fail)
   * [Always](#always)
   * [Then](#then)
+  * [Recover](#recover)
   * [When](#when)
 * [Installation](#installation)
 * [Author](#author)
@@ -227,6 +228,26 @@ promise1.thenInBackground({ data -> Int in
 promise2.thenInBackground({ data -> Promise<NSData> in
   //...
 })
+```
+
+### Recover
+Returns a new ***promise*** that can be used to continue the chain when an
+error was thrown.
+
+```swift
+let promise = Promise<String>()
+// Recover the chain
+promise
+  .recover({ error -> Promise<String> in
+    return Promise({
+      return "Recovered"
+    })
+  })
+  .done({ string in
+    print(string) // Recovered
+  })
+// Reject the promise
+promise.reject(Error.notFound)
 ```
 
 ### When

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -222,6 +222,9 @@ extension Promise {
 // MARK: - Recover
 
 extension Promise {
+  /**
+   Helps to recover from certain errors. Continues the chain if a given closure does not throw.
+   */
   public func recover(on queue: DispatchQueue = mainQueue,
                       _ body: @escaping (Error) throws -> T) -> Promise<T> {
     let promise = Promise<T>(queue: queue)
@@ -229,6 +232,9 @@ extension Promise {
     return promise
   }
 
+  /**
+   Helps to recover from certain errors. Continues the chain if a given closure does not throw.
+   */
   public func recover(on queue: DispatchQueue = mainQueue,
                       _ body: @escaping (Error) throws -> Promise<T>) -> Promise<T> {
     let promise = Promise<T>(queue: queue)
@@ -243,6 +249,9 @@ extension Promise {
     return promise
   }
 
+  /**
+   Adds a recover observer.
+   */
   private func addRecoverObserver(on queue: DispatchQueue, promise: Promise<T>,
                                   _ body: @escaping (Error) throws -> T?) {
     observer = Observer(queue: queue) { result in

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -123,7 +123,7 @@ open class Promise<T> {
 
   // MARK: - Helpers
 
-  private func update(state: State<T>?) {
+  fileprivate func update(state: State<T>?) {
     dispatch(queue) {
       guard let state = state, let result = state.result else {
         return
@@ -156,6 +156,45 @@ open class Promise<T> {
     observer = nil
   }
 
+  private func dispatch(_ queue: DispatchQueue, closure: @escaping () -> Void) {
+    if queue === instantQueue {
+      closure()
+    } else {
+      queue.async(execute: closure)
+    }
+  }
+}
+
+// MARK: - Then
+
+extension Promise {
+  public func then<U>(on queue: DispatchQueue = mainQueue, _ body: @escaping (T) throws -> U) -> Promise<U> {
+    let promise = Promise<U>(queue: queue)
+    addObserver(on: queue, promise: promise, body)
+    return promise
+  }
+
+  public func then<U>(on queue: DispatchQueue = mainQueue, _ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
+    let promise = Promise<U>(queue: queue)
+    addObserver(on: queue, promise: promise) { value -> U? in
+      let nextPromise = try body(value)
+      nextPromise.addObserver(on: queue, promise: promise) { value -> U? in
+        return value
+      }
+
+      return nil
+    }
+    return promise
+  }
+
+  public func thenInBackground<U>(_ body: @escaping (T) throws -> U) -> Promise<U> {
+    return then(on: backgroundQueue, body)
+  }
+
+  public func thenInBackground<U>(_ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
+    return then(on: backgroundQueue, body)
+  }
+
   fileprivate func addObserver<U>(on queue: DispatchQueue, promise: Promise<U>, _ body: @escaping (T) throws -> U?) {
     observer = Observer(queue: queue) { result in
       switch result {
@@ -175,49 +214,52 @@ open class Promise<T> {
     update(state: state)
   }
 
-  private func dispatch(_ queue: DispatchQueue, closure: @escaping () -> Void) {
-    if queue === instantQueue {
-      closure()
-    } else {
-      queue.async(execute: closure)
-    }
+  func asVoid() -> Promise<Void> {
+    return then(on: instantQueue) { _ in return }
   }
 }
 
-// MARK: - Then
+// MARK: - Recover
 
 extension Promise {
-  public func then<U>(on queue: DispatchQueue = mainQueue, _ body: @escaping (T) throws -> U) -> Promise<U> {
-    let promise = Promise<U>(queue: queue)
-    addObserver(on: queue, promise: promise, body)
-
+  public func recover(on queue: DispatchQueue = mainQueue,
+                      _ body: @escaping (Error) throws -> T) -> Promise<T> {
+    let promise = Promise<T>(queue: queue)
+    addRecoverObserver(on: queue, promise: promise, body)
     return promise
   }
 
-  public func then<U>(on queue: DispatchQueue = mainQueue, _ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
-    let promise = Promise<U>(queue: queue)
-
-    addObserver(on: queue, promise: promise) { value -> U? in
-      let nextPromise = try body(value)
-      nextPromise.addObserver(on: queue, promise: promise) { value -> U? in
+  public func recover(on queue: DispatchQueue = mainQueue,
+                      _ body: @escaping (Error) throws -> Promise<T>) -> Promise<T> {
+    let promise = Promise<T>(queue: queue)
+    addRecoverObserver(on: queue, promise: promise) { error -> T? in
+      let nextPromise = try body(error)
+      nextPromise.addObserver(on: queue, promise: promise) { value -> T? in
         return value
       }
 
       return nil
     }
-
     return promise
   }
 
-  public func thenInBackground<U>(_ body: @escaping (T) throws -> U) -> Promise<U> {
-    return then(on: backgroundQueue, body)
-  }
+  private func addRecoverObserver(on queue: DispatchQueue, promise: Promise<T>,
+                                  _ body: @escaping (Error) throws -> T?) {
+    observer = Observer(queue: queue) { result in
+      switch result {
+      case let .success(value):
+        promise.resolve(value)
+      case let .failure(error):
+        do {
+          if let result = try body(error) {
+            promise.resolve(result)
+          }
+        } catch {
+          promise.reject(error)
+        }
+      }
+    }
 
-  public func thenInBackground<U>(_ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
-    return then(on: backgroundQueue, body)
-  }
-
-  func asVoid() -> Promise<Void> {
-    return then(on: instantQueue) { _ in return }
+    update(state: state)
   }
 }

--- a/WhenTests/Shared/Helpers/SpecError.swift
+++ b/WhenTests/Shared/Helpers/SpecError.swift
@@ -2,4 +2,5 @@ import Foundation
 
 enum SpecError: Error {
   case notFound
+  case rejected
 }


### PR DESCRIPTION
`recover` returns a new ***promise*** that can be used to continue the chain when an
error was thrown.

```swift
let promise = Promise<String>()
// Recover the chain
promise
  .recover({ error -> Promise<String> in
    return Promise({
      return "Recovered"
    })
  })
  .done({ string in
    print(string) // Recovered
  })
// Reject the promise
promise.reject(Error.notFound)
```