### PR TITLE
Promise: Make cancel an open function

### DIFF
--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -84,7 +84,7 @@ open class Promise<T> {
   }
 
   /// Rejects a promise with the cancelled error.
-  public func cancel() {
+  open func cancel() {
     reject(PromiseError.cancelled)
   }
 


### PR DESCRIPTION
This change opens up `cancel()` to be overriden in other modules. This will be used in the Malibu framework (https://github.com/hyperoslo/malibu) to be able to use the latest version of When.