### PR TITLE
Add @discardableResult to promises that run in different queues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-osx_image: xcode8
-language: objective-c
+osx_image: xcode8.3
+language: swift
 
 before_install:
 - brew update

--- a/Sources/When/Promise.swift
+++ b/Sources/When/Promise.swift
@@ -182,13 +182,13 @@ open class Promise<T> {
 // MARK: - Then
 
 extension Promise {
-  public func then<U>(on queue: DispatchQueue = .main, _ body: @escaping (T) throws -> U) -> Promise<U> {
+  @discardableResult public func then<U>(on queue: DispatchQueue = .main, _ body: @escaping (T) throws -> U) -> Promise<U> {
     let promise = Promise<U>(queue: queue)
     addObserver(on: queue, promise: promise, body)
     return promise
   }
 
-  public func then<U>(on queue: DispatchQueue = .main, _ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
+  @discardableResult public func then<U>(on queue: DispatchQueue = .main, _ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
     let promise = Promise<U>(queue: queue)
     addObserver(on: queue, promise: promise) { value -> U? in
       let nextPromise = try body(value)
@@ -201,11 +201,11 @@ extension Promise {
     return promise
   }
 
-  public func thenInBackground<U>(_ body: @escaping (T) throws -> U) -> Promise<U> {
+  @discardableResult public func thenInBackground<U>(_ body: @escaping (T) throws -> U) -> Promise<U> {
     return then(on: backgroundQueue, body)
   }
 
-  public func thenInBackground<U>(_ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
+  @discardableResult public func thenInBackground<U>(_ body: @escaping (T) throws -> Promise<U>) -> Promise<U> {
     return then(on: backgroundQueue, body)
   }
 


### PR DESCRIPTION
This fixes warnings that occur when you use promises with dispatch queues. The fix is to add @discardableResult so that you don't have to keep a reference of the promise result.