### PR TITLE
Added 'When' dependency to RxWhen-tvOS target

### DIFF
--- a/When.xcodeproj/project.pbxproj
+++ b/When.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		D58B2C781E4131A00099F6D7 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58B2C771E4131A00099F6D7 /* RxSwift.framework */; };
 		D58CF69E1F7173C600EB104A /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* When.framework */; };
 		D58CF69F1F71741500EB104A /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* When.framework */; };
+		D5A7F9E821087B1400C393E9 /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5E4D5E21D98399C003770B2 /* When.framework */; };
 		D5B2E8AA1C3A780C00C0327D /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* When.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* When.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* When.framework */; };
 		D5C6299C1C3A8BDA007F7B7C /* StateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C629971C3A8BDA007F7B7C /* StateSpec.swift */; };
@@ -136,6 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5A7F9E821087B1400C393E9 /* When.framework in Frameworks */,
 				D58B2C781E4131A00099F6D7 /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Setup: Carthage only

Issue: 
When integrating `When` using `carthage bootstrap`, and not specifying the platforms, the build fails.

Reason: 
`Promise+Rx.swift` requires the `When` module, to which the linking was not included in the target and thus breaking the build.

If this was deliberate, and the change I propose is breaking/I have to go another route to solve this issue, please say so.

---

**Disclaimer**: I have never developed for tvOS, and am not aware of any restrictions that might be triggered by this, but given the fact that iOS works in the exact same way, and 'Allow app extension API only' is deselected, I have no reason to assume it'll fail.